### PR TITLE
Fix load corrupted index

### DIFF
--- a/ext/hnswlib/src/hnswalg.h
+++ b/ext/hnswlib/src/hnswalg.h
@@ -150,14 +150,20 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     }
 
     void clear() {
-        free(data_level0_memory_);
-        data_level0_memory_ = nullptr;
-        for (tableint i = 0; i < cur_element_count; i++) {
-            if (element_levels_[i] > 0)
-                free(linkLists_[i]);
+        if (data_level0_memory_ != nullptr) {
+            free(data_level0_memory_);
+            data_level0_memory_ = nullptr;
         }
-        free(linkLists_);
-        linkLists_ = nullptr;
+
+        if (linkLists_ != nullptr) {
+            for (tableint i = 0; i < cur_element_count; i++) {
+                if (element_levels_[i] > 0)
+                    free(linkLists_[i]);
+            }
+            free(linkLists_);
+            linkLists_ = nullptr;
+        }
+
         cur_element_count = 0;
         visited_list_pool_.reset(nullptr);
     }

--- a/spec/hnswlib/hierarchical_nsw_spec.rb
+++ b/spec/hnswlib/hierarchical_nsw_spec.rb
@@ -218,6 +218,15 @@ RSpec.describe Hnswlib::HierarchicalNSW do
     end
   end
 
+  describe '#load_index' do
+    context 'with an invalid file' do
+      it 'raises a runtime error' do
+        expect { index.load_index(__FILE__) }
+          .to(raise_error(RuntimeError))
+      end
+    end
+  end
+
   describe '#max_elements' do
     it 'returns the maximum number of elements' do
       expect(index.max_elements).to eq(max_elements)


### PR DESCRIPTION
## Problem

`Hnswlib::HierarchicalNSW.load_index` causes the program to exit with a core dump given a corrupted index:

```bash
$ bundle exec rspec spec/hnswlib/hierarchical_nsw_spec.rb:223
Run options: include {:locations=>{"./spec/hnswlib/hierarchical_nsw_spec.rb"=>[223]}}

Hnswlib::HierarchicalNSW
  #load_index
    with an invalid file
      raises a runtime error

Finished in 0.00326 seconds (files took 0.04765 seconds to load)
1 example, 0 failures

/Users/REDACTED/.rbenv/versions/3.1.3/bin/bundle: [BUG] Segmentation fault at 0x0000000000000020
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [arm64-darwin22]

-- Crash Report log information --------------------------------------------
   See Crash Report log file in one of the following locations:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0001 p:0000 s:0003 E:000710 (none) [FINISH]


-- Machine register context ------------------------------------------------
  x0: 0x0000600000b44460  x1: 0x0000000000000004  x2: 0x000000016d66e568
  x3: 0x0000600001c65380  x4: 0x0000600002d9d8c0  x5: 0x0000000000000006
  x6: 0x0000000000000002  x7: 0x0000000000000034 x18: 0x0000000000000000
 x19: 0x000000014100f400 x20: 0x0000000102f97bf0 x21: 0x00000001032ecff0
 x22: 0x0000000102f97b00 x23: 0x000000013196bb10 x24: 0x00000000000000d2
 x25: 0x000000000000001d x26: 0x00000001030b14a4 x27: 0x0000000000000028
 x28: 0x0000000102fc7ff8  lr: 0x000000010691d35c  fp: 0x000000016d66e4f0
  sp: 0x000000016d66e4c0
```

## Solution

In the `HierarchicalNSW` destructor, ensure `data_level0_memory_` and `linkLists_` are not null before freeing them.